### PR TITLE
Solana URI

### DIFF
--- a/utils/metaplex.js
+++ b/utils/metaplex.js
@@ -87,7 +87,7 @@ jsonFiles.forEach((file) => {
     symbol: symbol,
     description: description,
     seller_fee_basis_points: royaltyFee,
-    image: `${newEditionCount}.png`,
+    image: 'image.png',
     ...(external_url !== "" && { external_url }),
     attributes: jsonData.attributes,
     collection: {
@@ -98,7 +98,7 @@ jsonFiles.forEach((file) => {
       edition: jsonData.edition,
       files: [
         {
-          uri: `${baseUriPrefix}${newEditionCount}.png`,
+          uri: 'image.png',
           type: "image/png",
         },
       ],

--- a/utils/metaplex.js
+++ b/utils/metaplex.js
@@ -7,6 +7,7 @@ const basePath = isLocal ? process.cwd() : path.dirname(process.execPath);
 const chalk = require("chalk");
 
 const {
+  NFTName,
   collectionName,
   collectionFamily,
   symbol,
@@ -83,7 +84,7 @@ jsonFiles.forEach((file) => {
   const jsonData = JSON.parse(rawData);
 
   let tempMetadata = {
-    name: jsonData.name,
+    name: NFTName + ' ' + jsonData.name,
     symbol: symbol,
     description: description,
     seller_fee_basis_points: royaltyFee,
@@ -108,7 +109,7 @@ jsonFiles.forEach((file) => {
       ...(jsonData.imageHash !== undefined && {
         imageHash: jsonData.imageHash,
       }),
-      compiler: "HashLips Art Engine - NFTChef fork",
+      compiler: "HashLips Art Engine - NFTChef fork | SolanaJax",
     },
   };
   fs.writeFileSync(


### PR DESCRIPTION
When uploading on Solana it's important that the metadata has the placeholders image.png because it's exactly just that a placeholder - If we have numbers of any kind it will end up giving errors.